### PR TITLE
Included the secret in the manual and automated workflows

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   PROJECT_ID: ${{ secrets.GKE_PROJECT }}
+  FIRESTORE_KEY: ${{ secrets.FIRESTORE_KEY }}
   GKE_CLUSTER: cluster-1
   GKE_ZONE: us-central1-c
   DEPLOYMENT_NAME: temptool
@@ -82,7 +83,9 @@ jobs:
       # Deploy the Docker image to the GKE cluster
       - name: Deploy to GKE
         run: |-
+          printenv FIRESTORE_KEY > FIRESTORE_KEY
           ./kustomize edit set image gcr.io/temptool/temptool=gcr.io/$PROJECT_ID/$IMAGE:$GITHUB_SHA
+          ./kustomize edit add secret firestore_key --from-file=FIRESTORE_KEY
           ./kustomize build . | kubectl apply -f -
           kubectl rollout status deployment/$DEPLOYMENT_NAME
           kubectl get services -o wide

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -85,7 +85,7 @@ jobs:
         run: |-
           printenv FIRESTORE_KEY > FIRESTORE_KEY
           ./kustomize edit set image gcr.io/temptool/temptool=gcr.io/$PROJECT_ID/$IMAGE:$GITHUB_SHA
-          ./kustomize edit add secret firestore_key --from-file=FIRESTORE_KEY
+          ./kustomize edit add secret firestore-key --from-file=FIRESTORE_KEY
           ./kustomize build . | kubectl apply -f -
           kubectl rollout status deployment/$DEPLOYMENT_NAME
           kubectl get services -o wide

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM zdavid112z/temptool:0.3
 USER root
 
-ARG TEMPTOOL_PROD=1
+ENV TEMPTOOL_PROD 1
+ENV GOOGLE_APPLICATION_CREDENTIALS "/www/backend/firestore_key.json"
+ENV GCLOUD_PROJECT "temptool"
+
 COPY build/WebGL/WebGL /www/data
 COPY Server /www/backend
 COPY default.conf /etc/nginx/conf.d
+
 RUN chmod +x /www/backend/start.sh
 RUN chmod +x /www/backend/run_backend.sh
 RUN pip3 install -r /www/backend/requirements.txt

--- a/Server/run_backend.sh
+++ b/Server/run_backend.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
+cd /www/backend
+
 while true; do
-    cd /www/backend
     # Run server
     # python3 -m swagger_server
     python3 ServerFiles/server.py
-    sleep 100000
+    sleep 3
     echo "Backend crashed with exit code $?.  Respawning.." >&2
     sleep 1
 done

--- a/Server/start.sh
+++ b/Server/start.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+printenv FIRESTORE_KEY > /www/backend/firestore_key.json
+
 /www/backend/run_backend.sh &

--- a/deploy_no_unity_build.sh
+++ b/deploy_no_unity_build.sh
@@ -4,6 +4,10 @@
 # Must place the Unity build in build/WebGL/WebGL e.g. build/WebGL/WebGL/index.html must exist
 ######################
 
+######################
+# Must define the env FIRESTORE_KEY or have a file called FIRESTORE_KEY with the Firestore authentication key
+######################
+
 # Needs docker and kubectl installed and set up
 # Docker: https://docs.docker.com/get-docker/
 # Google SDK: https://cloud.google.com/sdk/docs/install#linux
@@ -18,6 +22,19 @@ PROJECT_ID=temptool
 IMAGE=temptool
 DEPLOYMENT_NAME=temptool
 TAG=$(uuidgen)
+
+# Check if FIRESTORE_KEY is defined and create a file with that name
+echo "Checking if FIRESTORE_KEY is defined as env"
+if [[ -v FIRESTORE_KEY ]]
+then
+    echo "FIRESTORE_KEY env exists, writing its contents to file FIRESTORE_KEY..."
+    rm -rf FIRESTORE_KEY
+    printenv FIRESTORE_KEY > FIRESTORE_KEY || echo "Failed to copy the contents of the FIRESTORE_KEY env variable into a file with the same name"
+else
+    echo "FIRESTORE_KEY env does not exist; file FIRESTORE_KEY must exist to not fail"
+fi
+
+test -f FIRESTORE_KEY || { echo "File FIRESTORE_KEY does not exist"; exit 1; }
 
 # Save kustomization.yaml
 cp kustomization.yaml __kustomization.yaml || { echo "Failed to backup old kustomization.yaml file"; exit 1; }
@@ -35,6 +52,7 @@ docker push "gcr.io/$PROJECT_ID/$IMAGE:$TAG" || { echo "Failed to push docker im
 # Deploy
 echo "#### Deploying to kubernetes ####"
 ./kustomize edit set image gcr.io/temptool/temptool=gcr.io/$PROJECT_ID/$IMAGE:$TAG || { echo "Failed to modify the kustomize file to use the newly built docker image"; exit 1; }
+./kustomize edit add secret firestore-key --from-file=FIRESTORE_KEY || { echo "Failed to modify the kustomize file to add the firestore auth"; exit 1; }
 ./kustomize build . | kubectl apply -f - || { echo "Failed to deploy"; exit 1; }
 kubectl rollout status deployment/$DEPLOYMENT_NAME || echo "Failed to watch deployment"
 kubectl get services -o wide || echo "Failed to get kubernetes services"

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -15,5 +15,12 @@ spec:
       containers:
       - name: temptool
         image: gcr.io/temptool/temptool
+        env:
+          - name: FIRESTORE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: firestore-key
+                key: FIRESTORE_KEY
+                optional: false
         ports:
         - containerPort: 80


### PR DESCRIPTION
The automated workflow uses a secret defined as a GitHub secret. This secret is then pasted into a file called FIRESTORE_KEY.

The manual workflow requires the user to have a file called FIRESTORE_KEY in the repo directory or an env variable called FIRESTORE_KEY that will then be pasted into the aforementioned file.

In both cases, the file is passed to kustomize, which creates an env variable with the same name. When the image is launched, it prints the contents of the image into the file /www/backend/firestore_key.json. The rest of the configuration is done in the Dockerfile.

Also the TEMPTOOL_PROD env variable did not show up in the pods. Changed the variable type from ARG to ENV to have it defined.